### PR TITLE
ListItemを別Componentに切り分けた

### DIFF
--- a/src/components/AddListScreen.tsx
+++ b/src/components/AddListScreen.tsx
@@ -13,7 +13,7 @@ import {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    // backgroundColor: '#fff',
     justifyContent: 'center',
     paddingHorizontal: 16,
   },
@@ -33,6 +33,7 @@ const styles = StyleSheet.create({
   },
   textInput: {
     flex: 4,
+    backgroundColor: '#fff',
     borderColor: 'rgba(14, 13, 13, .38)',
     borderWidth: 1,
     paddingHorizontal: 12,
@@ -44,6 +45,7 @@ const styles = StyleSheet.create({
   },
   multiTextInput: {
     flex: 4,
+    backgroundColor: '#fff',
     borderColor: 'rgba(14, 13, 13, .38)',
     borderWidth: 1,
     paddingHorizontal: 9,

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -4,7 +4,7 @@ import Entypo from 'react-native-vector-icons/Entypo';
 import { TabNavigator, TabBarBottom } from 'react-navigation';
 import ListScreen from './ListScreen';
 import AddListScreen from './AddListScreen';
-import { addMemo } from '../actions/index';
+import { addMemo, goDetail } from '../actions/index';
 
 const Tab = TabNavigator({
   List: {
@@ -20,30 +20,35 @@ const Tab = TabNavigator({
     },
   },
 }, {
-  tabBarComponent: TabBarBottom,
-  tabBarPosition: 'bottom',
-  tabBarOptions: {
-    style: {
-      backgroundColor: '#ffffff',
+    tabBarComponent: TabBarBottom,
+    tabBarPosition: 'bottom',
+    tabBarOptions: {
+      style: {
+        backgroundColor: '#ffffff',
+      },
+      indicatorStyle: {
+        backgroundColor: '#1fff1f',
+      },
+      activeTintColor: '#037aff',
+      inactiveTintColor: '#737373',
+      showLabel: true,
+      showIcon: true,
     },
-    indicatorStyle: {
-      backgroundColor: '#1fff1f',
-    },
-    activeTintColor: '#037aff',
-    inactiveTintColor: '#737373',
-    showLabel: true,
-    showIcon: true,
-  },
-});
+  });
 
 class HomeScreen extends React.Component<any, any> {
   constructor(props: any) {
     super(props);
     this.addNewMemoItem = this.addNewMemoItem.bind(this);
+    this.goDetailScreen = this.goDetailScreen.bind(this);
   }
 
-  addNewMemoItem(title: string, detail: string) {
+  addNewMemoItem(title: string, detail: string): void {
     this.props.screenProps.dispatch(addMemo(title, detail));
+  }
+
+  goDetailScreen(item: any): void {
+    this.props.screenProps.dispatch(goDetail(item));
   }
 
   render() {
@@ -51,9 +56,9 @@ class HomeScreen extends React.Component<any, any> {
     return (
       <Tab
         screenProps={{
-          navigation,
           memo,
           addNewMemoItem: this.addNewMemoItem,
+          goDetailScreen: this.goDetailScreen,
         }}
       />
     );

--- a/src/components/ListScreen.tsx
+++ b/src/components/ListScreen.tsx
@@ -1,44 +1,28 @@
 import * as React from 'react';
 import { StyleSheet, Text, FlatList, TouchableOpacity } from 'react-native';
 
-import { goDetail } from '../actions/index';
+import MemoListItem from './MemoListItem';
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 16,
-  },
-  item: {
-    borderBottomWidth: 1,
-    borderBottomColor: 'rgba(14, 13, 13, .38)',
-    marginVertical: 12,
-  },
-  heading: {
-    fontSize: 24,
-    color: 'rgba(14, 13, 13, .38)',
   },
 });
 
 
 class ListScreen extends React.Component<any, any> {
   render() {
-    const { navigation, memo } = this.props.screenProps;
-    console.log(1, memo);
+    const { goDetailScreen, memo } = this.props.screenProps;
     return (
       <FlatList
         data={memo}
+        extraData={memo}
         keyExtractor={(item: any, index: number) => String(index)}
         renderItem={({ item }) => (
-          <TouchableOpacity
-            key={item.key}
-            style={styles.item}
-            onPress={() => navigation.dispatch(goDetail(item))}
-          >
-            <Text style={styles.heading}>{item.title}</Text>
-          </TouchableOpacity>
+          <MemoListItem
+            item={item}
+            goDetailScreen={goDetailScreen}
+          />
         )}
         contentContainerStyle={styles.container}
       />

--- a/src/components/MemoListItem.tsx
+++ b/src/components/MemoListItem.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { StyleSheet, TouchableOpacity, Text, View, TouchableHighlight } from 'react-native';
+
+const styles = StyleSheet.create({
+  item: {
+    borderBottomWidth: 0.5,
+    borderBottomColor: '#575c59',
+  },
+  heading: {
+    padding: 8,
+    fontSize: 24,
+  },
+  sentence: {
+    padding: 8,
+    fontSize: 16,
+  },
+});
+
+interface ItemPropaties {
+  item: any,
+  goDetailScreen: any,
+}
+
+class MemoListItem extends React.Component<ItemPropaties, any> {
+  constructor(props: ItemPropaties) {
+    super(props);
+    this.handleOnPress = this.handleOnPress.bind(this);
+  }
+
+  handleOnPress(item: any) {
+    const { goDetailScreen } = this.props;
+    goDetailScreen(item);
+  }
+
+  render() {
+    const { item } = this.props;
+    return (
+      <View>
+        <TouchableOpacity
+          key={item.key}
+          style={styles.item}
+          onPress={() => this.handleOnPress(item)}
+        >
+          <View>
+            <Text style={styles.heading}>{item.title}</Text>
+            <Text
+              style={styles.sentence}
+              numberOfLines={3}
+            >
+              {item.detail}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+}
+
+export default MemoListItem;


### PR DESCRIPTION
## issue
close #13 

## 概要
* ListScreenにあったItemのLayoutをMemoListItemとして別Componentに切り分けることでLayoutの変更に強くした
* ついでに分かりにくいところにあったDetailScreenへのNavigationDispatchもHomeScreenへ持ってきて可読性をあげた